### PR TITLE
Cleaner Solution to Parse Using a Simple Regex

### DIFF
--- a/lib/email_parser.rb
+++ b/lib/email_parser.rb
@@ -13,4 +13,5 @@ class EmailParser
   def parse
     @emails.split(/ |, /).uniq
   end
+  
 end

--- a/lib/email_parser.rb
+++ b/lib/email_parser.rb
@@ -1,4 +1,16 @@
-# Build a class EmailParser that accepts a string of unformatted 
+# Build a class EmailParser that accepts a string of unformatted
 # emails. The parse method on the class should separate them into
 # unique email addresses. The delimiters to support are commas (',')
 # or whitespace (' ').
+
+class EmailParser
+  attr_accessor :emails
+
+  def initialize(emails)
+    @emails = emails
+  end
+
+  def parse
+    @emails.split(/ |, /).uniq
+  end
+end

--- a/spec/email_parser_spec.rb
+++ b/spec/email_parser_spec.rb
@@ -1,5 +1,5 @@
 describe "EmailParser" do
-  describe '#parser' do
+  describe '#parse' do
     it "parses CSV emails" do
       expect(EmailParser.new("avi@test.com, arel@test.com").parse).to eq(["avi@test.com", "arel@test.com"])
     end


### PR DESCRIPTION
The parse method can be done in one simple step by using a regex to split the original list of emails (i.e. "/ |, /"). This splits the list at either a space or a comma followed by a space, taking care of both delimiters in one step and avoiding the need to flatten the result.